### PR TITLE
Color types changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class MyComponent {
 
 #### Convert a color to another format
 ```
-#convert(color: anyColor, to: ColorTypes): anyColor
+#convert(color: basicColor, to: ColorTypes): basicColor
 ```
 
 Converts a color into a different format (eg. hex to RGB or HSL to hex).
@@ -64,7 +64,7 @@ colorUtilities.convert('hsl(39, 100%, 50%)', ColorTypes.rgb) // => 'rgb(255, 166
 
 #### Convert a raw color values to the color format
 ```
-#convertRawValuesTo(values: colorValues, to: ColorTypes): anyColor
+#convertRawValuesTo(values: colorValues, to: ColorTypes): basicColor
 ```
 
 Converts a raw color values (a triplet array: [R, G, B]) into a formatted string (eg. hex to RGB or HSL to hex).
@@ -87,7 +87,7 @@ colorUtilities.convertRawValuesTo([255, 165, 0], ColorTypes.hex) // => '#FFA500'
 
 #### Parse any color
 ```
-#parseColor(color: anyColor): colorValues
+#parseColor(color: basicColor): colorValues
 ```
 Transforms RGB, HSL or hex color into an array of RGB values. A generic variant of specific parsers dedicated for
 hex and RGB colors.
@@ -180,7 +180,7 @@ colorUtilities.parseHslColor('hsl(123, 100%, 100%)') // => [255, 255, 255]
 
 #### Validate a color
 ```
-#isValidColor(potentialColor?: anyColor): boolean
+#isValidColor(potentialColor?: basicColor): boolean
 ```
 Checks if the provided color is a valid hexadecimal color, an RGB color or an HSL color. Uses specific validators
 internally, so the edge cases from them applies here.
@@ -396,7 +396,7 @@ colorUtilities.normalizeHslColor('  HSL (  123,      100%,1%  )') // => 'hsl(123
 
 #### Calculate luminance of a color
 ```
-#calculateLuminanceOf(color: anyColor): number
+#calculateLuminanceOf(color: basicColor): number
 ```
 Calculates the relative luminance of a color, as defined in the
 [W3C Specification](https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef).
@@ -419,7 +419,7 @@ colorUtilities.calculateLuminanceOf('#FFA500') // => 0.48170267036309633
 
 #### Calculate contrast between two colors
 ```
-#calculateContrastRatio(color1: anyColor, color2: anyColor): number
+#calculateContrastRatio(color1: basicColor, color2: basicColor): number
 ```
 Calculates a contrast ratio between two colors, as defined in the
 [W3C Specification](https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef).
@@ -474,14 +474,14 @@ const blue = Color.blue
 
 #### Create a Color object
 ```
-Color.create(color?: anyColor | Color): Color
+Color.create(color?: anyColor): Color
 ```
 
 Creates a new color object (a factory method). Refer to the "Creation" section for more information.
 
 #### Check if an object is of the Color type
 ```
-Color.isColor(color?: anyColor | Color): boolean
+Color.isColor(color?: anyColor): boolean
 ```
 
 Tests if the provided color is a Color object.
@@ -517,7 +517,7 @@ color.luminance // => number: the color's luminance
 
 #### Set a new value
 ```
-#set(color: anyColor | Color): Color
+#set(color: anyColor): Color
 ```
 
 Sets a new color value of the color, returning a new, modified color. This method doesn't actually modify
@@ -539,7 +539,7 @@ black !== white // => true
 
 #### Calculate contrast with another color
 ```
-#calculateContrastTo(color: anyColor | Color): number
+#calculateContrastTo(color: anyColor): number
 ```
 
 Calculates the contrast of the color compared to another one.
@@ -559,7 +559,7 @@ blac.calculateContrastTo(white) // => 21
 
 #### Check the color equality with another one
 ```
-#equals(color: anyColor | Color): boolean
+#equals(color: anyColor): boolean
 ```
 
 Tests if the color object is of the same color as the tested one.

--- a/README.md
+++ b/README.md
@@ -599,5 +599,65 @@ const orange = Color.create('#FFA500')
 color.toString() // => "#FFA500"
 ```
 
+## Colors types
+Since all color are essentaily strings, the library aliases them for more explicit typing. Those types are exported for
+consumers to use them together with the library or as a standalone definitions.
+
+### Basic types
+There are three basic color types:
+- `hexColor` used for colors in the HEX format,
+- `rgbColor` used for colors in the RGB format,
+- `hexColor` used for colors in the HSL format.
+
+There's also a `basicColor` type representing all three possible types.
+
+To use them, just import required definitions from the `@kolory/color-utilities` module.
+
+#### Examples
+```
+import {basicColor, hexColor, rgbColor, hslColor} from '@kolory/color-utilities'
+
+const red: hexColor = '#FF0000'
+const green: rgbColor = 'rgb(0, 255, 0)'
+const blue: hslColor = 'hsl(240, 100%, 50%)'
+
+let cameleon: basicColor
+cameleon = '#FF0000'
+cameleon = rgb(0, 255, 0)'
+cameleon = 'hsl(240, 100%, 50%)'
+```
+
+### Value types
+In the internal calculations and raw colors management the library uses three value types representing values colors
+are consisted of.
+
+- `hexValue` is used for a single value of the hex color (eg. `A5` in `#FFA500`),
+- `hexColorValues`  is a triplet of `hexValue`s and represents all three values of a hex color (eg. `['FF', 'A5', '00']` in `#FFA500`),
+- `colorValues` is a triplet of the color's RGB values (eg. `[255, 165, 0]` in `#FFA500`).
+
+#### Examples
+```
+import {colorValues, hexColorValues} from '@kolory/color-utilities'
+
+const rawValuesOfOrange: colorValues = new ColorUtilities().parseColor('#FFA500')
+const hexValuesOfOrange: hexColorValues = new ColorUtilities().splitHexColor('#FFA500')
+```
+
+### Any color
+When using the [Color Object](https://github.com/kolory/color-utilities#color-object) class that is not included in
+any of the basic colors, the `anyColor` type comes in handy. It's a union type of a `basicColor` type ane the type 
+of the `Color` class.
+
+#### Examples
+```
+import {anyColor} from '@kolory/color-utilities'
+
+let rainbow: anyColor
+rainbow = '#FF0000'
+rainbow = rgb(0, 255, 0)'
+rainbow = 'hsl(240, 100%, 50%)'
+rainbow = Color.create('#FFA500')
+```
+
 ## License
 MIT

--- a/src/color.spec.ts
+++ b/src/color.spec.ts
@@ -1,9 +1,9 @@
 import {Color} from './color'
-import {anyColor} from './types'
+import {basicColor} from './types'
 import {strictlyValidHexColors, validRgbColors, invalidColors} from './test-colors'
 import {ColorUtilities} from './library'
 
-const basicColor: anyColor = '#FFFFFF'
+const baseColor: basicColor = '#FFFFFF'
 
 describe('Color object', () => {
   const utils = new ColorUtilities()
@@ -32,8 +32,8 @@ describe('Color object', () => {
     })
 
     it('should allow using a valid color during creation', () => {
-      expect(new Color(basicColor).hex).toBe(basicColor)
-      expect(Color.create(basicColor).hex).toBe(basicColor)
+      expect(new Color(baseColor).hex).toBe(baseColor)
+      expect(Color.create(baseColor).hex).toBe(baseColor)
       strictlyValidHexColors.forEach(color => expect(Color.create(color).hex).toBe(utils.normalizeHexColor(color)))
       validRgbColors.forEach(color => expect(Color.create(color).rgb).toBe(utils.normalizeRgbColor(color)))
 

--- a/src/color.ts
+++ b/src/color.ts
@@ -196,7 +196,7 @@ export class Color {
    * @returns {number} The contrast ratio.
    */
   calculateContrastTo(color: anyColor): number {
-    return Color.utilities.calculateContrastRatio(this.hex, color instanceof Color ? color.hex : color)
+    return Color.utilities.calculateContrastRatio(this.hex, Color.isColor(color) ? color.hex : color)
   }
 
   /**

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,4 +1,4 @@
-import {anyColor, hexColor, RGBColor, HSLColor, colorValues} from './types'
+import {anyColor, hexColor, rgbColor, hslColor, colorValues} from './types'
 import {ColorUtilities} from './library'
 import {ColorTypes} from './color-types-enum'
 
@@ -78,11 +78,11 @@ export class Color {
     return this.getColor(ColorTypes.hex)
   }
 
-  get rgb(): RGBColor {
+  get rgb(): rgbColor {
     return this.getColor(ColorTypes.rgb)
   }
 
-  get hsl(): HSLColor {
+  get hsl(): hslColor {
     return this.getColor(ColorTypes.hsl)
   }
 

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,4 +1,4 @@
-import {basicColor, hexColor, rgbColor, hslColor, colorValues} from './types'
+import {anyColor, basicColor, hexColor, rgbColor, hslColor, colorValues} from './types'
 import {ColorUtilities} from './library'
 import {ColorTypes} from './color-types-enum'
 
@@ -43,20 +43,20 @@ export class Color {
   /**
    * Creates the new Color instance from a color string or another Color object.
    *
-   * @param {basicColor | Color} color value to be set.
+   * @param {anyColor} color value to be set.
    */
-  static create(color?: basicColor | Color | number): Color
+  static create(color?: anyColor | number): Color
 
   /**
    * Factory method creating a Color object instance. Provide a valid hex, RGB, HSL color or another Color object.
    * For the insight of how the color is created, refer to the constructor's documentation.
    *
-   * @param {basicColor | Color | number} colorOrRed red part of the RGB color or a color.
+   * @param {anyColor | number} colorOrRed red part of the RGB color or a color.
    * @param {number} green part of the color.
    * @param {number} blue part of the color.
    * @returns {Color} The new Color instance.
    */
-  static create(colorOrRed?: basicColor | Color | number, green?: number, blue?: number): Color {
+  static create(colorOrRed?: anyColor | number, green?: number, blue?: number): Color {
     if (typeof colorOrRed === 'number') {
       return new Color(colorOrRed, green, blue)
     } else {
@@ -67,10 +67,10 @@ export class Color {
   /**
    * Utility method to check if an object is a Color object.
    *
-   * @param {basicColor | Color} color to be checked.
+   * @param {anyColor} color to be checked.
    * @returns {boolean} Is it a Color object?
    */
-  static isColor(color?: basicColor | Color): color is Color {
+  static isColor(color?: anyColor): color is Color {
     return color instanceof Color
   }
 
@@ -118,9 +118,9 @@ export class Color {
   /**
    * Creates the new Color instance from a color string or another Color object.
    *
-   * @param {basicColor | Color} color value to be set.
+   * @param {anyColor} color value to be set.
    */
-  constructor(color?: basicColor | Color)
+  constructor(color?: anyColor)
 
   /**
    * Color object is created from:
@@ -136,12 +136,12 @@ export class Color {
    * @throws TypeError
    * @throws RangeError
    *
-   * @param {basicColor | Color | number} colorOrRed red part of the RGB color or a color.
+   * @param {anyColor | number} colorOrRed red part of the RGB color or a color.
    * @param {number} green part of the color.
    * @param {number} blue part of the color.
    * @returns {Color} The new Color object.
    */
-  constructor(colorOrRed?: basicColor | Color | number, green?: number, blue?: number) {
+  constructor(colorOrRed?: anyColor | number, green?: number, blue?: number) {
     /* tslint:disable:cyclomatic-complexity */
     if (typeof colorOrRed === 'number') {
       this.color = this.getColorFromRawValues(colorOrRed, green, blue)
@@ -179,10 +179,10 @@ export class Color {
    * not using any value.
    *
    * @throws TypeError
-   * @param {basicColor | Color} color to be used when setting a new value.
+   * @param {anyColor} color to be used when setting a new value.
    * @returns {Color} A new Color instance with the value set.
    */
-  set(color: basicColor | Color): Color {
+  set(color: anyColor): Color {
     if (!Color.isColor(color) && !Color.utilities.isValidColor(color)) {
       this.throwInvalidColor(color)
     }
@@ -192,20 +192,20 @@ export class Color {
   /**
    * Calculates the Color's contrast in comparision to another color.
    *
-   * @param {basicColor | Color} color to which te contrast will be calculated.
+   * @param {anyColor} color to which te contrast will be calculated.
    * @returns {number} The contrast ratio.
    */
-  calculateContrastTo(color: basicColor | Color): number {
+  calculateContrastTo(color: anyColor): number {
     return Color.utilities.calculateContrastRatio(this.hex, color instanceof Color ? color.hex : color)
   }
 
   /**
    * Checks if the Color's value is the same as the tested one.
    *
-   * @param {basicColor | Color} color to be tested with.
+   * @param {anyColor} color to be tested with.
    * @returns {boolean} Is the value the same?
    */
-  equals(color: basicColor | Color): boolean {
+  equals(color: anyColor): boolean {
     let values: colorValues
     if (Color.isColor(color)) {
       values = (color as Color).values

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,4 +1,4 @@
-import {anyColor, hexColor, rgbColor, hslColor, colorValues} from './types'
+import {basicColor, hexColor, rgbColor, hslColor, colorValues} from './types'
 import {ColorUtilities} from './library'
 import {ColorTypes} from './color-types-enum'
 
@@ -43,20 +43,20 @@ export class Color {
   /**
    * Creates the new Color instance from a color string or another Color object.
    *
-   * @param {anyColor | Color} color value to be set.
+   * @param {basicColor | Color} color value to be set.
    */
-  static create(color?: anyColor | Color | number): Color
+  static create(color?: basicColor | Color | number): Color
 
   /**
    * Factory method creating a Color object instance. Provide a valid hex, RGB, HSL color or another Color object.
    * For the insight of how the color is created, refer to the constructor's documentation.
    *
-   * @param {anyColor | Color | number} colorOrRed red part of the RGB color or a color.
+   * @param {basicColor | Color | number} colorOrRed red part of the RGB color or a color.
    * @param {number} green part of the color.
    * @param {number} blue part of the color.
    * @returns {Color} The new Color instance.
    */
-  static create(colorOrRed?: anyColor | Color | number, green?: number, blue?: number): Color {
+  static create(colorOrRed?: basicColor | Color | number, green?: number, blue?: number): Color {
     if (typeof colorOrRed === 'number') {
       return new Color(colorOrRed, green, blue)
     } else {
@@ -67,10 +67,10 @@ export class Color {
   /**
    * Utility method to check if an object is a Color object.
    *
-   * @param {anyColor | Color} color to be checked.
+   * @param {basicColor | Color} color to be checked.
    * @returns {boolean} Is it a Color object?
    */
-  static isColor(color?: anyColor | Color): color is Color {
+  static isColor(color?: basicColor | Color): color is Color {
     return color instanceof Color
   }
 
@@ -118,9 +118,9 @@ export class Color {
   /**
    * Creates the new Color instance from a color string or another Color object.
    *
-   * @param {anyColor | Color} color value to be set.
+   * @param {basicColor | Color} color value to be set.
    */
-  constructor(color?: anyColor | Color)
+  constructor(color?: basicColor | Color)
 
   /**
    * Color object is created from:
@@ -136,12 +136,12 @@ export class Color {
    * @throws TypeError
    * @throws RangeError
    *
-   * @param {anyColor | Color | number} colorOrRed red part of the RGB color or a color.
+   * @param {basicColor | Color | number} colorOrRed red part of the RGB color or a color.
    * @param {number} green part of the color.
    * @param {number} blue part of the color.
    * @returns {Color} The new Color object.
    */
-  constructor(colorOrRed?: anyColor | Color | number, green?: number, blue?: number) {
+  constructor(colorOrRed?: basicColor | Color | number, green?: number, blue?: number) {
     /* tslint:disable:cyclomatic-complexity */
     if (typeof colorOrRed === 'number') {
       this.color = this.getColorFromRawValues(colorOrRed, green, blue)
@@ -179,10 +179,10 @@ export class Color {
    * not using any value.
    *
    * @throws TypeError
-   * @param {anyColor | Color} color to be used when setting a new value.
+   * @param {basicColor | Color} color to be used when setting a new value.
    * @returns {Color} A new Color instance with the value set.
    */
-  set(color: anyColor | Color): Color {
+  set(color: basicColor | Color): Color {
     if (!Color.isColor(color) && !Color.utilities.isValidColor(color)) {
       this.throwInvalidColor(color)
     }
@@ -192,20 +192,20 @@ export class Color {
   /**
    * Calculates the Color's contrast in comparision to another color.
    *
-   * @param {anyColor | Color} color to which te contrast will be calculated.
+   * @param {basicColor | Color} color to which te contrast will be calculated.
    * @returns {number} The contrast ratio.
    */
-  calculateContrastTo(color: anyColor | Color): number {
+  calculateContrastTo(color: basicColor | Color): number {
     return Color.utilities.calculateContrastRatio(this.hex, color instanceof Color ? color.hex : color)
   }
 
   /**
    * Checks if the Color's value is the same as the tested one.
    *
-   * @param {anyColor | Color} color to be tested with.
+   * @param {basicColor | Color} color to be tested with.
    * @returns {boolean} Is the value the same?
    */
-  equals(color: anyColor | Color): boolean {
+  equals(color: basicColor | Color): boolean {
     let values: colorValues
     if (Color.isColor(color)) {
       values = (color as Color).values
@@ -231,18 +231,18 @@ export class Color {
    * Returns a color value in requested format.
    *
    * @param {ColorType} ofType type of the returned color.
-   * @returns {anyColor} The color string.
+   * @returns {basicColor} The color string.
    */
-  private getColor(ofType: ColorTypes): anyColor {
+  private getColor(ofType: ColorTypes): basicColor {
     return Color.utilities.convertRawValuesTo(this.color, ofType)
   }
 
   /**
    * A shortcut to throw the invalid color error.
    *
-   * @param {anyColor} color that is invalid.
+   * @param {basicColor} color that is invalid.
    */
-  private throwInvalidColor(color?: anyColor): never {
+  private throwInvalidColor(color?: basicColor): never {
     throw new TypeError(`Can't set a new color. "${color}" is not in a recognized format.`)
   }
 }

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,5 +1,6 @@
-import {hexColor, hexColorValues, colorValues, RGBColor, anyColor, HSLColor} from './types'
+import {hexColor, hexColorValues, colorValues, rgbColor, anyColor, hslColor} from './types'
 import {ColorTypes} from './color-types-enum'
+import {Color} from './color'
 
 /**
  * Utility library for parsing colors, validation, normalization and some other useful features.
@@ -129,9 +130,9 @@ export class ColorUtilities {
    * Converts the RGB values into an RGB color.
    *
    * @param {colorValues} values to be converted.
-   * @returns {RGBColor} outcome RGB color.
+   * @returns {rgbColor} outcome RGB color.
    */
-  private convertValuesToRgb(values: colorValues): RGBColor {
+  private convertValuesToRgb(values: colorValues): rgbColor {
     return `rgb(${values.join(', ')})`
   }
 
@@ -140,9 +141,9 @@ export class ColorUtilities {
    * Algorithm taken from Wikipedia: https://en.wikipedia.org/wiki/HSL_and_HSV#General_approach
    *
    * @param {colorValues} values to be converted.
-   * @returns {RGBColor} outcome HSL color.
+   * @returns {rgbColor} outcome HSL color.
    */
-  private convertValuesToHsl(values: colorValues): HSLColor {
+  private convertValuesToHsl(values: colorValues): hslColor {
     /* tslint:disable:cyclomatic-complexity */
     const [r, g, b] = values.map(v => v / 255)
     const M = Math.max(r, g, b)
@@ -213,10 +214,10 @@ export class ColorUtilities {
    * Transforms the RGB color string into its color values.
    *
    * @throws TypeError
-   * @param {RGBColor} rgbColor to be transformed
+   * @param {rgbColor} rgbColor to be transformed
    * @returns {colorValues} RGB triplet of the provided hex color
    */
-  parseRgbColor(rgbColor: RGBColor): colorValues {
+  parseRgbColor(rgbColor: rgbColor): colorValues {
     return this.splitRgbColor(this.normalizeRgbColor(rgbColor)) as colorValues
   }
 
@@ -224,10 +225,10 @@ export class ColorUtilities {
    * Transforms the HSL color string into its color values.
    *
    * @throws TypeError
-   * @param {HSLColor} hslColor to be transformed.
+   * @param {hslColor} hslColor to be transformed.
    * @returns {colorValues} RGB triplet of the provided hex color.
    */
-  parseHslColor(hslColor: HSLColor): colorValues {
+  parseHslColor(hslColor: hslColor): colorValues {
     return this.splitHslColor(this.normalizeHslColor(hslColor)) as colorValues
   }
 
@@ -271,10 +272,10 @@ export class ColorUtilities {
    * 'Xrgb(0, 1, 2)' => false
    * 'rgb(256, 255, 255)' => false
    *
-   * @param {RGBColor} potentialRgbColor Might-be-valid-or-not rgb color string.
+   * @param {rgbColor} potentialRgbColor Might-be-valid-or-not rgb color string.
    * @returns {boolean} Is it a valid rgb color string?
    */
-  isValidRgbColor(potentialRgbColor?: RGBColor): boolean {
+  isValidRgbColor(potentialRgbColor?: rgbColor): boolean {
     if (!potentialRgbColor) {
       return false
     } else {
@@ -292,10 +293,10 @@ export class ColorUtilities {
    * 'hsl(400, 200%, 300%) => false
    * 'hsl(123, 12, 44) => false
    *
-   * @param {HSLColor?} potentialColor Color to be validated.
+   * @param {hslColor?} potentialColor Color to be validated.
    * @returns {boolean} Is this a valid HSL?
    */
-  isValidHslColor(potentialColor?: HSLColor): boolean {
+  isValidHslColor(potentialColor?: hslColor): boolean {
     if (!potentialColor) {
       return false
     } else {
@@ -307,10 +308,10 @@ export class ColorUtilities {
   /**
    * Checks if the HSL values are i proper ranges.
    *
-   * @param {HSLColor} potentialColor Color to be validated.
+   * @param {hslColor} potentialColor Color to be validated.
    * @returns {boolean} Are the values in range?
    */
-  private areHslValuesInRange(potentialColor: HSLColor): boolean {
+  private areHslValuesInRange(potentialColor: hslColor): boolean {
     return this.isRangeValid(potentialColor, this.validateHslRange)
   }
 
@@ -342,11 +343,11 @@ export class ColorUtilities {
   /**
    * Range validator. Takes a color to be validated and validating function used in the Array#every call.
    *
-   * @param {RGBColor | HSLColor} color RGB or HSL color to be validated.
+   * @param {rgbColor | hslColor} color RGB or HSL color to be validated.
    * @param {Function} rangeValidator Function to be used for validation.
    * @returns {boolean} Are values in proper ranges?
    */
-  private isRangeValid(color: RGBColor | HSLColor, rangeValidator: (value: number, index?: number) => boolean):
+  private isRangeValid(color: rgbColor | hslColor, rangeValidator: (value: number, index?: number) => boolean):
   boolean {
     const values = this.getValues(color)
     return values.every(stringValue => !/^0\d/.test(stringValue)) &&
@@ -356,11 +357,11 @@ export class ColorUtilities {
   /**
    * Finds out if the color is in a proper format. The format is a regular expression
    *
-   * @param {RGBColor | HSLColor} color to be validated
+   * @param {rgbColor | hslColor} color to be validated
    * @param {RegExp} validatingRegEx to use against the color.
    * @returns {boolean} Is the color properly formatted?
    */
-  private isFormatValid(color: RGBColor | HSLColor, validatingRegEx: RegExp): boolean {
+  private isFormatValid(color: rgbColor | hslColor, validatingRegEx: RegExp): boolean {
     return validatingRegEx.test(this.trimAndLowercase(color))
   }
 
@@ -386,10 +387,10 @@ export class ColorUtilities {
    * @example
    * "rgba(255, 0, 1)" => [255, 0, 1]
    *
-   * @param {RGBColor} rgbColor An RGB color string.
+   * @param {rgbColor} rgbColor An RGB color string.
    * @returns {colorValues} A triplet of the color values.
    */
-  splitRgbColor(rgbColor: RGBColor): colorValues {
+  splitRgbColor(rgbColor: rgbColor): colorValues {
     return this.getValues(rgbColor).map(Number) as colorValues
   }
 
@@ -398,10 +399,10 @@ export class ColorUtilities {
    *
    * Algorithm taken from Wikipedia: https://en.wikipedia.org/wiki/HSL_and_HSV#From_HSL
    *
-   * @param {HSLColor} hslColor to be split.
+   * @param {hslColor} hslColor to be split.
    * @returns {colorValues} The color's RGB values.
    */
-  splitHslColor(hslColor: HSLColor): colorValues {
+  splitHslColor(hslColor: hslColor): colorValues {
     const [hue, saturation, lightness] = this.getValues(hslColor).map(Number)
     const normalizedSaturation = saturation / 100
     const normalizedLightness = lightness / 100
@@ -476,10 +477,10 @@ export class ColorUtilities {
    * @example
    * ' RGB  ( 11,  11,11  )   ' => 'rgb(11, 11, 11)
    *
-   * @param {RGBColor} rgbColor to be normalized.
-   * @returns {RGBColor} Normalized rgb color string.
+   * @param {rgbColor} rgbColor to be normalized.
+   * @returns {rgbColor} Normalized rgb color string.
    */
-  normalizeRgbColor(rgbColor: RGBColor): RGBColor {
+  normalizeRgbColor(rgbColor: rgbColor): rgbColor {
     const potentialColor = rgbColor.toLowerCase()
     this.throwIfInvalidRgbColor(potentialColor)
     return potentialColor.replace(/\s/g, '').replace(/,/g, ', ')
@@ -491,10 +492,10 @@ export class ColorUtilities {
    * @example
    * '   HSL  (123,    49%,51%  )' => 'hsl(123, 49%, 51%)'
    *
-   * @param {HSLColor} hslColor to be normalized
-   * @returns {HSLColor} Normalized color.
+   * @param {hslColor} hslColor to be normalized
+   * @returns {hslColor} Normalized color.
    */
-  normalizeHslColor(hslColor: HSLColor): HSLColor {
+  normalizeHslColor(hslColor: hslColor): hslColor {
     const potentialColor = hslColor.toLowerCase()
     this.throwIfInvalidHslColor(potentialColor)
     return potentialColor.replace(/\s/g, '').replace(/,/g, ', ')
@@ -535,9 +536,9 @@ export class ColorUtilities {
   /**
    * A shortcut to throw an error when provided color was invalid.
    *
-   * @param {RGBColor} rgbColor An invalid color
+   * @param {rgbColor} rgbColor An invalid color
    */
-  private throwInvalidRgbColor(rgbColor?: RGBColor): never {
+  private throwInvalidRgbColor(rgbColor?: rgbColor): never {
     throw new TypeError(`Using invalid RGB color format. Used "${rgbColor}" but it should look like`
       + `"rgb(123, 123, 123)".`)
   }
@@ -545,9 +546,9 @@ export class ColorUtilities {
   /**
    * Validation combined with the error throwing. Just to make the code that needs this behavior shorter.
    *
-   * @param {RGBColor} rgbColor An invalid color
+   * @param {rgbColor} rgbColor An invalid color
    */
-  private throwIfInvalidRgbColor(rgbColor?: RGBColor): void {
+  private throwIfInvalidRgbColor(rgbColor?: rgbColor): void {
     if (!this.isValidRgbColor(rgbColor)) {
       this.throwInvalidRgbColor(rgbColor)
     }
@@ -556,9 +557,9 @@ export class ColorUtilities {
   /**
    * Validation combined with the error throwing. Just to make the code that needs this behavior shorter.
    *
-   * @param {HSLColor} hslColor that will be checked.
+   * @param {hslColor} hslColor that will be checked.
    */
-  private throwIfInvalidHslColor(hslColor: HSLColor): void {
+  private throwIfInvalidHslColor(hslColor: hslColor): void {
     if (!this.isValidHslColor(hslColor)) {
       this.throwInvalidHslColor(hslColor)
     }
@@ -567,9 +568,9 @@ export class ColorUtilities {
   /**
    * A shortcut to throw an error when provided color was invalid.
    *
-   * @param {HSLColor} hslColor An invalid color.
+   * @param {hslColor} hslColor An invalid color.
    */
-  private throwInvalidHslColor(hslColor?: HSLColor): never {
+  private throwInvalidHslColor(hslColor?: hslColor): never {
     throw new TypeError(`Using invalid RGB color format. Used "${hslColor}" but it should look like` +
       `hsl(123, 50%, 49%).`)
   }

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,6 +1,5 @@
-import {hexColor, hexColorValues, colorValues, rgbColor, anyColor, hslColor} from './types'
+import {hexColor, hexColorValues, colorValues, rgbColor, basicColor, hslColor} from './types'
 import {ColorTypes} from './color-types-enum'
-import {Color} from './color'
 
 /**
  * Utility library for parsing colors, validation, normalization and some other useful features.
@@ -30,10 +29,10 @@ export class ColorUtilities {
    * Calculates the relative luminance of a color. Based on the W3C Recommendation.
    * https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
    *
-   * @param {anyColor} color for which to calculate the luminance
+   * @param {basicColor} color for which to calculate the luminance
    * @returns {number} relative luminance
    */
-  calculateLuminanceOf(color: anyColor): number {
+  calculateLuminanceOf(color: basicColor): number {
     const multipliers = [0.2126, 0.7152, 0.0722]
     return this.parseColor(color)
       .map(value => value / 255)
@@ -46,11 +45,11 @@ export class ColorUtilities {
    * order of color values, so it doesn't matter which color is brighter.
    * https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
    *
-   * @param {anyColor} color1 Calculate this color's contrast ratio…
-   * @param {anyColor} color2 to this color.
+   * @param {basicColor} color1 Calculate this color's contrast ratio…
+   * @param {basicColor} color2 to this color.
    * @returns {number} the contrast ratio of provided colors
    */
-  calculateContrastRatio(color1: anyColor, color2: anyColor): number {
+  calculateContrastRatio(color1: basicColor, color2: basicColor): number {
     return [this.calculateLuminanceOf(color1), this.calculateLuminanceOf(color2)]
       .sort((a, b) => b - a)
       .map(value => value + 0.05)
@@ -61,10 +60,10 @@ export class ColorUtilities {
    * Finds out what color encoding type is provided. If a not valid color was provided, the
    * ColorTypes.invalidType is returned.
    *
-   * @param {anyColor} color Resolve the type of this color.
+   * @param {basicColor} color Resolve the type of this color.
    * @returns {ColorTypes} The color's type.
    */
-  resolveColorType(color: anyColor): ColorTypes {
+  resolveColorType(color: basicColor): ColorTypes {
     if (this.isValidHexColor(color)) {
       return ColorTypes.hex
     } else if (this.isValidRgbColor(color)) {
@@ -84,11 +83,11 @@ export class ColorUtilities {
    * @example
    * colorUtil.convert('#F03402', ColorTypes.hsl) // => 'hsl(13, 98%, 47%)'
    *
-   * @param {anyColor} color to be converted.
+   * @param {basicColor} color to be converted.
    * @param {ColorTypes} to this format.
-   * @returns {anyColor} converted color.
+   * @returns {basicColor} converted color.
    */
-  convert(color: anyColor, to: ColorTypes): anyColor {
+  convert(color: basicColor, to: ColorTypes): basicColor {
     return this.convertRawValuesTo(this.parseColor(color), to)
   }
 
@@ -99,7 +98,7 @@ export class ColorUtilities {
    * @param {ColorTypes} to this type convert.
    * @returns {any} The converted color.
    */
-  convertRawValuesTo(values: colorValues, to: ColorTypes): anyColor {
+  convertRawValuesTo(values: colorValues, to: ColorTypes): basicColor {
     switch (to) {
     case ColorTypes.hex:
       return this.convertValuesToHex(values)
@@ -183,10 +182,10 @@ export class ColorUtilities {
    * A generic parser. Resolves the color type before passing it to specific parsers.
    *
    * @throws TypeError
-   * @param {anyColor} color A color to be parsed.
+   * @param {basicColor} color A color to be parsed.
    * @returns {colorValues} RGB triplet of the provided hex color
    */
-  parseColor(color: anyColor): colorValues {
+  parseColor(color: basicColor): colorValues {
     switch (this.resolveColorType(color)) {
     case ColorTypes.hex:
       return this.parseHexColor(color)
@@ -237,10 +236,10 @@ export class ColorUtilities {
   /**
    * Validates the provided color against any specific color type.
    *
-   * @param {anyColor?} potentialColor Color to be validated.
+   * @param {basicColor?} potentialColor Color to be validated.
    * @returns {boolean} Is this color valid?
    */
-  isValidColor(potentialColor?: anyColor): boolean {
+  isValidColor(potentialColor?: basicColor): boolean {
     return this.isValidHexColor(potentialColor) || this.isValidRgbColor(potentialColor)
       || this.isValidHslColor(potentialColor)
   }
@@ -333,10 +332,10 @@ export class ColorUtilities {
   /**
    * Removes unnecessary spaces and makes the color lowercased.
    *
-   * @param {anyColor} color to be normalized.
+   * @param {basicColor} color to be normalized.
    * @returns {string} Normalized color.
    */
-  private trimAndLowercase(color: anyColor): anyColor {
+  private trimAndLowercase(color: basicColor): basicColor {
     return color.replace(/\s/g, '').toLowerCase()
   }
 
@@ -437,10 +436,10 @@ export class ColorUtilities {
    * Extracts the values from colors using the regular expression. Returned value is a string, since some
    * methods need to validate it's format before passing it further as a number.
    *
-   * @param {anyColor} color from which the values will be extracted.
+   * @param {basicColor} color from which the values will be extracted.
    * @returns {string[]} Array of values.
    */
-  private getValues(color: anyColor): string[] {
+  private getValues(color: basicColor): string[] {
     return color.match(/\d{1,3}/g) as string[]
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
 export type rgbColor = string
 export type hexColor = string
 export type hslColor = string
-export type anyColor = rgbColor | hexColor | hslColor
+export type basicColor = rgbColor | hexColor | hslColor
 
 // Values
 export type hexValue = string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,11 @@
+import {Color} from './color'
+
 // Colors
 export type rgbColor = string
 export type hexColor = string
 export type hslColor = string
 export type basicColor = rgbColor | hexColor | hslColor
+export type anyColor = basicColor | Color
 
 // Values
 export type hexValue = string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
-export type RGBColor = string
+export type rgbColor = string
 export type hexColor = string
-export type HSLColor = string
+export type hslColor = string
 export type hexValue = string
 export type hexColorValues = [hexValue, hexValue, hexValue]
-export type anyColor = RGBColor | hexColor
+export type anyColor = rgbColor | hexColor
 export type colorValues = [number, number, number]

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,10 @@
+// Colors
 export type rgbColor = string
 export type hexColor = string
 export type hslColor = string
+export type anyColor = rgbColor | hexColor | hslColor
+
+// Values
 export type hexValue = string
 export type hexColorValues = [hexValue, hexValue, hexValue]
-export type anyColor = rgbColor | hexColor
 export type colorValues = [number, number, number]


### PR DESCRIPTION
- [breaking] `anyColor` is now `basicColor`,
- [breaking] `anyColor` includes the `Color` type,
- [fix] `hslColor` added one of the `basicColor`,
- [chore] types documentation.