### PR TITLE
Fix/color conversion with small values

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-safari-launcher": "^1.0.0",
     "karma-typescript": "^2.1.2",
-    "typescript": "^2.0.9",
+    "typescript": "~2.1.0",
     "tslint": "^4.0.2",
     "tslint-eslint-rules": "^3.0.0",
     "tslint-microsoft-contrib": "^2.0.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kolory/color-utilities",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Color utilities and parsers",
   "main": "index.js",
   "scripts": {

--- a/src/color.spec.ts
+++ b/src/color.spec.ts
@@ -54,8 +54,10 @@ describe('Color object', () => {
 
     it('should not allow using invalid colors during creation', () => {
       invalidColors.forEach(color => expect(() => new Color(color)).toThrowError(TypeError))
-      expect(() => new Color(-1, 0, 0)).toThrowError(RangeError)
-      expect(() => new Color(100, 100, 300)).toThrowError(RangeError)
+      expect(() => new Color(-1, 0, 0)).toThrow()
+      expect(() => new Color(100, 100, 300)).toThrow()
+      expect(() => new Color(100, 100, 300)).toThrow()
+      expect(() => new Color(100, NaN, 100)).toThrow()
     })
   })
 

--- a/src/color.ts
+++ b/src/color.ts
@@ -19,18 +19,6 @@ export class Color {
    */
   static utilities = new ColorUtilities()
 
-  /* tslint:disable:completed-docs */
-  /* Colors shortcuts. */
-  static readonly black = Color.create('#000000')
-  static readonly white = Color.create('#FFFFFF')
-  static readonly red = Color.create('#FF0000')
-  static readonly green = Color.create('#00FF00')
-  static readonly blue = Color.create('#0000FF')
-
-  // Current value.
-  private color: colorValues
-  /* tslint:enable:completed-docs */
-
   /**
    * Creates the new Color instance from RGB values.
    *
@@ -73,6 +61,18 @@ export class Color {
   static isColor(color?: anyColor): color is Color {
     return color instanceof Color
   }
+
+  /* tslint:disable:completed-docs */
+  /* Colors shortcuts. */
+  static readonly black = Color.create('#000000')
+  static readonly white = Color.create('#FFFFFF')
+  static readonly red = Color.create('#FF0000')
+  static readonly green = Color.create('#00FF00')
+  static readonly blue = Color.create('#0000FF')
+
+  // Current value.
+  private color: colorValues
+  /* tslint:enable:completed-docs */
 
   get hex(): hexColor {
     return this.getColor(ColorTypes.hex)
@@ -143,7 +143,7 @@ export class Color {
    */
   constructor(colorOrRed?: anyColor | number, green?: number, blue?: number) {
     /* tslint:disable:cyclomatic-complexity */
-    if (typeof colorOrRed === 'number') {
+    if (this.isNumber(colorOrRed)) {
       this.color = this.getColorFromRawValues(colorOrRed, green, blue)
     } else if (!colorOrRed) {
       return Color.white
@@ -166,11 +166,30 @@ export class Color {
    * @returns {colorValues} Valid values.
    */
   private getColorFromRawValues(red: number, green?: number, blue?: number): colorValues {
-    if ([red, green, blue].every(value => value >= 0 && value <= 255)) {
+    if (this.areValuesValidRGB([red, green, blue])) {
       return [red, green, blue] as colorValues
     } else {
-      throw new RangeError(`At leas one value from [${red}, ${green}, ${blue}] of out of the valid [0-255] range.`)
+      throw new Error(`At leas one value from [${red}, ${green}, ${blue}] is not a number or outside of the allowed` +
+        `range [0-255] range.`)
     }
+  }
+
+  /**
+   * Checks if the provided value is a raw number.
+   * @param {number | anyColor | undefined | null} value to be checked.
+   * @returns {boolean} Is it a raw number?
+   */
+  private isNumber(value: number | anyColor | undefined | null): value is number {
+    return typeof value === 'number'
+  }
+
+  /**
+   * Checks if the three RGB values are valid numbers and are in the allowed range.
+   * @param {(number | undefined | null)[]} values Values to be checked.
+   * @returns {number|undefined} Are the values valid?
+   */
+  private areValuesValidRGB(values: (number | undefined | null)[]): boolean {
+    return values.reduce((outcome, value) => outcome && this.isNumber(value) && value >= 0 && value <= 255, true)
   }
 
   /**

--- a/src/library.spec.ts
+++ b/src/library.spec.ts
@@ -80,6 +80,8 @@ describe('Color utilities', () => {
       expect(colorUtil.convert('#fff', ColorTypes.rgb)).toBe('rgb(255, 255, 255)')
       expect(colorUtil.convert('#FFA500', ColorTypes.rgb)).toBe('rgb(255, 165, 0)')
       expect(colorUtil.convert('hsl(39, 100%, 50%)', ColorTypes.rgb)).toBe('rgb(255, 166, 0)')
+      expect(colorUtil.convert('rgb(76, 11, 95)', ColorTypes.hex)).toBe('#4C0B5F')
+      expect(colorUtil.convert('rgb(9, 10, 11)', ColorTypes.hex)).toBe('#090A0B')
 
       // HSL conversion requires a special attention.
       expect(colorUtil.convert('#FFFFFF', ColorTypes.hsl)).toBe('hsl(0, 100%, 100%)')

--- a/src/library.ts
+++ b/src/library.ts
@@ -138,10 +138,14 @@ export class ColorUtilities {
    */
   private convertStringTypeToEnum(type: 'hex' | 'rgb' | 'hsl'): ColorTypes {
     switch (type) {
-    case 'hex': return ColorTypes.hex
-    case 'rgb': return ColorTypes.rgb
-    case 'hsl': return ColorTypes.hsl
-    default: return ColorTypes.invalidType
+    case 'hex':
+      return ColorTypes.hex
+    case 'rgb':
+      return ColorTypes.rgb
+    case 'hsl':
+      return ColorTypes.hsl
+    default:
+      return ColorTypes.invalidType
     }
   }
 
@@ -174,7 +178,8 @@ export class ColorUtilities {
   private convertValuesToHex(values: colorValues): hexColor {
     return this.normalizeHexColor(
       values
-        .map(value => value < 10 ? '0' + String(value) : value.toString(16))
+        .map(value => value.toString(16))
+        .map(in16value => in16value.length === 1 ? '0' + in16value : in16value)
         .reduce((color, value) => color + value, '#')
     )
   }
@@ -400,8 +405,8 @@ export class ColorUtilities {
    * @param {Function} rangeValidator Function to be used for validation.
    * @returns {boolean} Are values in proper ranges?
    */
-  private isRangeValid(color: rgbColor | hslColor, rangeValidator: (value: number, index?: number) => boolean):
-  boolean {
+  private isRangeValid(color: rgbColor
+                         | hslColor, rangeValidator: (value: number, index?: number) => boolean): boolean {
     const values = this.getValues(color)
     return values.every(stringValue => !/^0\d/.test(stringValue)) &&
       values.map(value => Number(value)).every(rangeValidator)

--- a/src/library.ts
+++ b/src/library.ts
@@ -516,16 +516,15 @@ export class ColorUtilities {
    * @returns {hexColor}
    */
   normalizeHexColor(hexColor: hexColor): hexColor {
-    const potentialColor = hexColor[0] !== '#' ? '#' + hexColor : hexColor
+    const potentialColor = (hexColor[0] !== '#' ? '#' + hexColor : hexColor).toUpperCase()
     this.throwIfInvalidHexColor(potentialColor)
 
     if (potentialColor.length === 4) {
       return potentialColor.split('')
         .reduce((acc, digit, index) => index !== 0 ? [...acc, digit, digit] : acc, ['#'])
         .join('')
-        .toUpperCase()
     } else {
-      return potentialColor.toUpperCase()
+      return potentialColor
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,11 +17,19 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "stripInternal": true,
-    "types": ["jasmine"],
-    "lib": ["es6"]
+    "types": [
+      "jasmine"
+    ],
+    "lib": [
+      "es6"
+    ]
   },
-  "include": ["./src/**/*", "index.ts"],
+  "include": [
+    "./src/**/*",
+    "index.ts"
+  ],
   "exclude": [
-    "node_modules", "dist"
+    "node_modules",
+    "dist"
   ]
 }


### PR DESCRIPTION
Resolves an issue with RGB values smaller than 16 that - during the HEX conversion - created invalid HEX string.

Also makes sure the error message during conversion will show uppercased value, instead of misleading lowercased.